### PR TITLE
Check for a response of 'false' from authorization server to allow unauthorized access

### DIFF
--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -395,7 +395,7 @@ class ExternalAuthorizer(_AbstractAuthorizer):
             'fp': info.src_img_fp,
         }
         response = requests.post(self.protected_url, data=data).text
-        return bool(response == 'true')
+        return bool(response != 'false')
         
 
     def is_authorized(self, info, request):


### PR DESCRIPTION
Check for a response of 'false' to allow unauthorized access, instead of not 'true' in case there's an invalid response from the server.

Loris makes this call once per object id to determine if it needs to check for authorization on an image in subsequent calls.  (It caches the response from this call.)  In our case we are checking with our DL to see if the image ID is open to all viewers.  Our DL responds with "true" or "false."  We should check of a "false" response from the server and only open access if that is received.